### PR TITLE
Improve dashboard charts and visualizations

### DIFF
--- a/web/app/dashboard/dashboard-stream.tsx
+++ b/web/app/dashboard/dashboard-stream.tsx
@@ -81,6 +81,70 @@ function RecoverySparkline({ history, current }: { history: number[], current: n
   )
 }
 
+// 7-day HRV sparkline (history is most-recent-first; we reverse to oldest-first)
+function HRVSparkline({ history, current }: { history: number[], current: number }) {
+  const data = [...history].slice(0, 6).reverse().concat(current).map((v, i) => ({ i, v }))
+  if (data.length < 2) return null
+  const last = data[data.length - 1].v
+  const prev = data[data.length - 2].v
+  const up = last >= prev
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-text-tertiary w-14 flex-shrink-0">7d HRV</span>
+      <div className="flex-1 h-8">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <Line type="monotone" dataKey="v" dot={false} strokeWidth={1.5}
+              stroke={up ? '#8b5cf6' : '#f97316'} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      <span className={`text-xs font-medium flex-shrink-0 ${up ? 'text-purple-400' : 'text-orange-500'}`}>
+        {up ? '▲' : '▼'}
+      </span>
+    </div>
+  )
+}
+
+// Compact sleep stage segmented bar
+function SleepStageBar({
+  deepMinutes, remMinutes, coreMinutes, awakeMinutes, totalMinutes,
+}: {
+  deepMinutes: number, remMinutes: number, coreMinutes: number, awakeMinutes: number, totalMinutes: number,
+}) {
+  if (totalMinutes < 30) return null
+  const stages = [
+    { label: 'Deep', mins: deepMinutes, color: '#6366f1' },
+    { label: 'REM', mins: remMinutes, color: '#8b5cf6' },
+    { label: 'Core', mins: coreMinutes, color: '#a78bfa' },
+    { label: 'Awake', mins: awakeMinutes, color: '#6b7280' },
+  ].filter(s => s.mins > 0)
+  return (
+    <div className="px-4 pb-3">
+      <div className="flex h-2 rounded-full overflow-hidden gap-[1px]">
+        {stages.map(({ label, mins, color }) => (
+          <div
+            key={label}
+            title={`${label}: ${Math.floor(mins / 60)}h ${mins % 60}m`}
+            className="h-full first:rounded-l-full last:rounded-r-full"
+            style={{ width: `${(mins / totalMinutes) * 100}%`, backgroundColor: color }}
+          />
+        ))}
+      </div>
+      <div className="flex gap-3 mt-1.5 flex-wrap">
+        {stages.map(({ label, mins, color }) => (
+          <div key={label} className="flex items-center gap-1">
+            <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+            <span className="text-[10px] text-text-tertiary">
+              {label} {Math.floor(mins / 60)}h{mins % 60 > 0 ? ` ${mins % 60}m` : ''}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 const DEFAULT_STEP_GOAL = 10000
 const DEFAULT_CAL_GOAL = 500
 const DEFAULT_SLEEP_GOAL_MINUTES = 480 // 8 hours
@@ -499,6 +563,14 @@ export function DashboardStream({
   const sleepHours = Math.floor(metrics.sleep.duration / 60)
   const sleepMins = metrics.sleep.duration % 60
   const sleepDisplay = metrics.sleep.duration > 0 ? `${sleepHours}h ${sleepMins}m` : '—'
+  // Sleep quality label based on duration (Good ≥7h, Fair ≥6h, Poor <6h)
+  const sleepQualityLabel = metrics.sleep.duration >= 420
+    ? 'Good · ' + sleepDisplay
+    : metrics.sleep.duration >= 360
+    ? 'Fair · ' + sleepDisplay
+    : metrics.sleep.duration > 0
+    ? 'Poor · ' + sleepDisplay
+    : undefined
 
   // Zero-state: true when all main metrics have no synced data yet
   const allMetricsEmpty = metrics.steps === 0 && sleepDisplay === '—' && todayHrv === null && metrics.restingHR === null
@@ -1019,6 +1091,12 @@ export function DashboardStream({
               icon={<Moon className="w-5 h-5" />}
               label="Sleep"
               value={sleepDisplay}
+              sublabel={
+                metrics.sleep.duration >= 420 ? 'Good quality'
+                : metrics.sleep.duration >= 360 ? 'Fair quality'
+                : metrics.sleep.duration > 0 ? 'Poor — below goal'
+                : undefined
+              }
               color="sleep"
               expandContent={
                 <div className="space-y-3">
@@ -1038,7 +1116,7 @@ export function DashboardStream({
                       </span>
                     </div>
                   )}
-                  {/* Sleep stages */}
+                  {/* Sleep stages detail bars */}
                   {hasSleepStages && (
                     <div className="space-y-1.5 pt-1 border-t border-border">
                       {[
@@ -1068,6 +1146,16 @@ export function DashboardStream({
                 </div>
               }
             />
+            {/* Always-visible sleep stage segmented bar */}
+            {hasSleepStages && (
+              <SleepStageBar
+                deepMinutes={lastSleepRecord?.deep_minutes ?? 0}
+                remMinutes={lastSleepRecord?.rem_minutes ?? 0}
+                coreMinutes={lastSleepRecord?.core_minutes ?? 0}
+                awakeMinutes={lastSleepRecord?.awake_minutes ?? 0}
+                totalMinutes={totalSleepTracked}
+              />
+            )}
             {sleepStreak > 0 && (
               <MetricRow
                 icon={<Moon className="w-5 h-5" />}
@@ -1087,7 +1175,10 @@ export function DashboardStream({
               expandContent={
                 <div className="space-y-3">
                   <MetricDetail label="HRV" value={todayHrv != null ? `${Math.round(todayHrv)} ms` : '—'} />
-                  {avgRestingHR != null && <MetricDetail label="7-day Average" value={`${avgRestingHR} bpm`} />}
+                  {todayHrv != null && hrvHistory.length >= 2 && (
+                    <HRVSparkline history={hrvHistory} current={todayHrv} />
+                  )}
+                  {avgRestingHR != null && <MetricDetail label="7-day Avg RHR" value={`${avgRestingHR} bpm`} />}
                 </div>
               }
             />

--- a/web/app/score/score-client.tsx
+++ b/web/app/score/score-client.tsx
@@ -188,10 +188,20 @@ export function HealthScoreClient({
     return '→'
   }
 
-  // 30-day chart data
+  // 30-day chart data — include raw recovery_score from the database for comparison
   const chartData = scored
     .filter((d) => d.overall !== null)
-    .map((d) => ({ date: fmtDate(d.date), score: d.overall!, sleep: d.sleep, activity: d.activity, recovery: d.recovery }))
+    .map((d) => {
+      const summary = summaries.find((s) => s.date === d.date)
+      return {
+        date: fmtDate(d.date),
+        score: d.overall!,
+        sleep: d.sleep,
+        activity: d.activity,
+        recovery: d.recovery,
+        rawRecovery: (summary?.recovery_score != null && summary.recovery_score > 0) ? summary.recovery_score : null,
+      }
+    })
 
   const overallScore = currentOverall ?? 0
 
@@ -261,7 +271,7 @@ export function HealthScoreClient({
       {chartData.length >= 5 && (
         <div className="bg-surface rounded-xl border border-border p-4">
           <h3 className="text-sm font-medium text-text-secondary mb-3">30-Day Score History</h3>
-          <ResponsiveContainer width="100%" height={160}>
+          <ResponsiveContainer width="100%" height={180}>
             <LineChart data={chartData} margin={{ top: 4, right: 4, left: -8, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
               <XAxis dataKey="date" tick={{ fontSize: 10, fill: 'var(--color-text-secondary)' }} axisLine={false} tickLine={false} interval="preserveStartEnd" />
@@ -271,10 +281,17 @@ export function HealthScoreClient({
               <Line type="monotone" dataKey="sleep" name="sleep" stroke="#818cf8" strokeWidth={1} dot={false} strokeDasharray="3 2" />
               <Line type="monotone" dataKey="activity" name="activity" stroke="#4ade80" strokeWidth={1} dot={false} strokeDasharray="3 2" />
               <Line type="monotone" dataKey="recovery" name="recovery" stroke="#fb923c" strokeWidth={1} dot={false} strokeDasharray="3 2" />
+              <Line type="monotone" dataKey="rawRecovery" name="raw recovery" stroke="#f59e0b" strokeWidth={1.5} dot={false} connectNulls strokeDasharray="4 2" />
             </LineChart>
           </ResponsiveContainer>
           <div className="flex flex-wrap gap-3 mt-2 text-xs text-text-secondary">
-            {[{ color: '#60a5fa', label: 'Overall' }, { color: '#818cf8', label: 'Sleep' }, { color: '#4ade80', label: 'Activity' }, { color: '#fb923c', label: 'Recovery' }].map(({ color, label }) => (
+            {[
+              { color: '#60a5fa', label: 'Overall' },
+              { color: '#818cf8', label: 'Sleep' },
+              { color: '#4ade80', label: 'Activity' },
+              { color: '#fb923c', label: 'Recovery' },
+              { color: '#f59e0b', label: 'Raw Recovery' },
+            ].map(({ color, label }) => (
               <div key={label} className="flex items-center gap-1.5">
                 <div className="w-3 h-0.5" style={{ backgroundColor: color }} />
                 {label}


### PR DESCRIPTION
## Summary

Three targeted visualization improvements to the KQuarks web dashboard:

### Task 1: HRV Trend Sparkline
- Added `HRVSparkline` component (7-day purple/orange line chart) inside the Resting Heart Rate metric row's expand section
- Uses existing `hrvHistory` array (past 6 days) + today's HRV, rendered oldest→newest
- Color indicates trend: purple = improving, orange = declining

### Task 2: Sleep Quality Breakdown
- Added `SleepStageBar` component: always-visible horizontal segmented bar showing Deep / REM / Core / Awake proportions in color
- Added quality sublabel to the Sleep metric row (Good ≥7h / Fair ≥6h / Poor <6h)
- Stage bar appears only when actual stage data is available from `sleep_records`

### Task 3: Health Score History Chart Enhancement
- Added raw `recovery_score` from `daily_summaries` as a distinct amber dashed line on the 30-day score history chart
- Updated legend to include "Raw Recovery" entry
- Increased chart height from 160→180px for better legibility

All changes pass `tsc --noEmit` with zero errors.