### PR TITLE
Fix Swift syntax errors in WorkoutsView and LifetimeStatsView

### DIFF
--- a/ios/KQuarks/Views/LifetimeStatsView.swift
+++ b/ios/KQuarks/Views/LifetimeStatsView.swift
@@ -235,7 +235,6 @@ struct LifetimeStatsView: View {
             if let year = bestYear {
                 factLine("Best year: \(year) with \(bestYearSessions) sessions")
             }
-            }
         }
         .padding()
         .background(Color.teal.opacity(0.08))

--- a/ios/KQuarks/Views/WorkoutsView.swift
+++ b/ios/KQuarks/Views/WorkoutsView.swift
@@ -96,12 +96,10 @@ struct WorkoutsView: View {
                             Image(systemName: "calendar.badge.clock")
                         }
                         NavigationLink(destination: WorkoutAnalyticsView()) {
-    Image(systemName: "chart.xyaxis.line")
-}
-NavigationLink(destination: HRZonesView()) {
-    Image(systemName: "heart.fill")
-}
                             Image(systemName: "chart.xyaxis.line")
+                        }
+                        NavigationLink(destination: HRZonesView()) {
+                            Image(systemName: "heart.fill")
                         }
                     }
                 }


### PR DESCRIPTION
Fixes pre-existing syntax errors causing build failures.

## Changes

**WorkoutsView.swift**: Removed duplicate/mis-indented `NavigationLink` blocks for `WorkoutAnalyticsView` and `HRZonesView` that were inserted inside the cancellationAction toolbar item, leaving a stray `Image` expression and mismatched braces.

**LifetimeStatsView.swift**: Removed an extra closing brace inside `funFactsCard`'s `VStack` that made the property body malformed.

Both files now pass `swiftc -parse` with no errors.